### PR TITLE
Add deprecation notice - direct users to modern repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> This repository is legacy and is no longer actively maintained. For the latest DEXI drone development, please use:
+> 
+> - **[dexi-sim-ftw](https://github.com/DroneBlocks/dexi-sim-ftw)** - Complete PX4 simulator with ROS2, Node-RED, Unity, and Docker
+> - **[dexi-os](https://github.com/DroneBlocks/dexi-os)** - Image builder for DEXI drone software
+> - **[node-red-dexi](https://github.com/DroneBlocks/node-red-dexi)** - Node-RED nodes for DEXI development
+> - **Individual ROS2 packages:** dexi_interfaces, dexi_offboard, dexi_bringup, dexi_led, dexi_camera, etc.
+> 
+> The open issues in this repo are for historical/planning purposes. New development should use the repos above.
+
+---
+
 # Setup ROS2
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a prominent deprecation notice to the top of the README directing users to modern DEXI repositories.

## Motivation

This legacy repo has 37 open issues (mostly R&D/planning tasks) but is no longer actively developed. The DEXI project has evolved into modular ROS2 packages and a complete simulator (dexi-sim-ftw).

Without clear deprecation guidance, new users may waste time setting up the old monolithic repo instead of using the current architecture.

## Changes

- Added blockquote warning at the top of README
- Links to active repos: dexi-sim-ftw, dexi-os, node-red-dexi
- Explains that open issues are historical
- Preserves all original documentation below the notice

## Related

This supports the broader cleanup documented in the comprehensive repo audit (see dexi-sim-ftw/DRONEBLOCKS_REPO_FIXES.md).